### PR TITLE
Remove all pin versions from conda

### DIFF
--- a/conda/rsclf-pytorch.yaml
+++ b/conda/rsclf-pytorch.yaml
@@ -13,7 +13,7 @@ dependencies:
   - numpy
   - pip
   - pip:
-    - keras==3.4.1
+    - keras
     - h5py
     - scipy
     - matplotlib

--- a/conda/rsclf-tensorflow.yaml
+++ b/conda/rsclf-tensorflow.yaml
@@ -7,9 +7,9 @@ dependencies:
   - python=3.11
   - pip
   - pip:
-    - keras==3.4.1
+    - keras
     - scipy
     - --extra-index-url https://pypi.nvidia.com
-    - tensorflow[and-cuda]==2.16.2
+    - tensorflow[and-cuda]
     - matplotlib
     - polars

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "raw-speech-classification"
-version = "1.0.2"
+version = "1.0.3"
 license = {file = "LICENSES/GPL-3.0-only.txt"}
 authors = [
     { name = "S. Pavankumar Dubagunta" },


### PR DESCRIPTION
I have removed the pin deps to Keras 3.4.1 and to corresponding PyTorch and Tensorflow. The package works nice with the latest one, namely Keras 3.6.